### PR TITLE
Fix bug elements won't scroll into view if html height is set to 100%

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ History
 * Fixed issues with `.value()` for radio buttons and text areas
 * Fixed bug with setting radio buttons when there are more than
   one set of radio buttons in the form.
+* Fixed bug where elements wouldn't scroll into view if html height is set to
+  100%
 
 0.1.4
 +++++

--- a/django_functest/funcselenium.py
+++ b/django_functest/funcselenium.py
@@ -443,8 +443,8 @@ class FuncSeleniumMixin(CommonMixin):
         # http://www.howtocreate.co.uk/tutorials/javascript/browserwindow
         return self.execute_script("""return [window.innerWidth,
                                               window.innerHeight,
-                                              document.documentElement.offsetWidth,
-                                              document.documentElement.offsetHeight];""")
+                                              document.documentElement.scrollWidth,
+                                              document.documentElement.scrollHeight];""")
 
     def _scroll_position(self):
         return self.execute_script("""return [document.documentElement.scrollTop,


### PR DESCRIPTION
Setting body to height: 100% used to be reasonably common in the IE6 era (something to do with vertical positioning I think?). This commit fixes the clamping of _scroll_into_view in this case.

Note: Only tested with Firefox.