### PR TITLE
Add note about lxml and MacOS to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ docs/_build
 
 # Tests
 tmp_static/
-tests/django_functest_tests/uploads
+tests/uploads

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,26 @@ See `CONTRIBUTING.rst <CONTRIBUTING.rst>`_ for information about running the tes
 contributing to django-functest.
 
 
+Building on Mac OS
+------------------
+
+While [this lxml bug](https://bugs.launchpad.net/lxml/+bug/1949271) is in
+effect `lxml` cannot handle certain unicode characters in HTML (or XML!)
+documents on Mac OS, including the emoji used in one of the files in the test
+suite.
+
+Therefore, if you are affected by this bug, you will find that certain tests
+fail with the error `lxml.etree.ParserError: Document is empty`.
+
+You will also find that `lxml`'s own test suite fails on your machine.
+
+A workaround is to compile `libxml2` yourself, which `lxml` will take care of for you.
+To do this, run the following:
+
+```
+STATICBUILD=true python -m pip install lxml --force-reinstall --no-binary=:all:
+```
+
 Paid support
 ------------
 


### PR DESCRIPTION
Running the test suite, I see failures like this:

```
../../.virtualenvs/django-functest/lib/python3.10/site-packages/lxml/html/__init__.py:878: in fromstring
    doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

html = '<!DOCTYPE html>\n<html>\n  <head>\n    <meta charset="UTF-8">\n\n    <title>Stuff</title>\n    <style>\n      #hovera...ed as a DOM node:\n      var html = "<p id=\'this-is-not-a-dom-node\'>Hello</p>";\n    </script>\n  </body>\n</html>\n'
parser = <lxml.html.HTMLParser object at 0x1062e6e80>, ensure_head_body = False, kw = {'base_url': None}, value = None

    def document_fromstring(html, parser=None, ensure_head_body=False, **kw):
        if parser is None:
            parser = html_parser
        print(parser)
        print(html)
        value = etree.fromstring(html, parser, **kw)
        if value is None:
>           raise etree.ParserError(
                "Document is empty")
```

Investigation shows that the strings passed to `fromstring` from either webtest or selenium, in the former's case from `response.testbody` and in the latter's from `self._driver.page_source` cause this error, unless those methods receive an `encode('utf-8')` to turn them into bytes.

I find the suite runs fine with that added. I note that the [last actions run](https://github.com/django-functest/django-functest/actions/runs/4745450494) succeeded, and I'm running the same version, so I wondered if something had changed in Django 4.2 to cause this.

Alternative ways to get tests to pass: 
- remove the 😀 char from the `test_misc.html` file (not acceptable, obviously!)
- for webtest, pass `response.body` instead of `response.testbody` when building the `PyQuery` object. I don't yet understand the purpose of `testbody` vs `body`, tho I note webtest itself prefers `testbody` when loading a pq object.

I admit I couldn't see how to specify which version of django to run against locally, so I thought I'd try and run on Actions (this also to confirm that some transitive dep hadn't changed since that last successful run) — and in doing so I raised this PR  on the main repo prematurely, sorry!

Hopefully this issue is specific to my local setup. I'm using an M1 Mac... so native libraries like those lxml depends upon might be the cause?? If not, I'll propose a change to encode at the point of parsing. Ideally we'd look at headers rather than a hardcoded `utf-8`, though, I guess?
