### PR TITLE
Avoid depending on Keys.CONTROL as it means something different on MacOS

### DIFF
--- a/src/django_functest/funcselenium.py
+++ b/src/django_functest/funcselenium.py
@@ -667,7 +667,10 @@ class FuncSeleniumMixin(CommonMixin, FuncBaseMixin):
                 # We avoid 'elem.clear()' as it fires events unhelpfully.
                 # Alternative methods from:
                 # https://stackoverflow.com/questions/7732125/clear-text-from-textarea-with-selenium
-                elem.send_keys(Keys.CONTROL + "a")
+                # Note CONTROL + 'a' then BACKSPACE doesn't work on MacOS as
+                # the key is called COMMAND, hence HOME/SHIFT + END
+                elem.send_keys(Keys.HOME)
+                elem.send_keys(Keys.SHIFT, Keys.END)
                 elem.send_keys(Keys.DELETE)
 
             elem.send_keys(self._normalize_linebreaks(val))


### PR DESCRIPTION
Running the test suite on MacOS before this change results in failures like the following:

```
test_common.py::TestFuncSeleniumCommonChrome::test_fill - AssertionError: assert 'RockNew name' == 'New name'
```

This is because the 'name' input is not emptied before we attempt to fill it. That is because the key `CONTROL` does not do the same thing on MacOS as it does on other platforms. (By convention, MacOS uses `COMMAND`).

Retaining the policy of not using `elem.clear()`, replace this with a hopefully more robust method to select the contents of the field.

I've chosen to commit without any additional tests, as this is a common operation and all existing tests now pass.